### PR TITLE
Added possibility to exclude notebooks from delete

### DIFF
--- a/bricker.template.yml
+++ b/bricker.template.yml
@@ -9,6 +9,10 @@ dbc_folders:
 
 dbc_envfile_path: .../...
 
+# dbc_notebook_exclude:
+#   - "_text_to_exclude"
+#   - "_new_text-to_exlude"
+
 github_branches:
   prod: master
   dev:  dev

--- a/bricker/__init__.py
+++ b/bricker/__init__.py
@@ -187,6 +187,11 @@ def up(force):
             click.echo("No problem - aborting")
             return
 
+    # If settings contains excluded notebooks then exclude them from being deleted
+    if 'dbc_notebook_exclude' in settings().keys():
+        for exclude in settings()['dbc_notebook_exclude']:
+            only_dbc = [n for n in only_dbc if exclude not in n]
+
     p = Pool(10)
     # Uploading with no parallellization due to race condition issues in DBC
     list(map(upload_notebook, (both + only_local)))

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name='bricker',
     description='CLI tool for syncing a Databricks folder structure with a local git repo.',
-    version='0.4.3',
+    version='0.4.4',
     author='sporveien',
     author_email='brick@sporveien.com',
     url='https://github.com/sporveien/bricker',


### PR DESCRIPTION
To avoid deletion upon bricker up the setting dbc_notebook_exclude can be used to exclude notebooks from deletion.